### PR TITLE
Fix projects pagination and console startup error

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 
 require "bundler/setup"
+require "logger"
 require "bizside/redmine/client"
 
 # You can add fixtures and/or initialization code here to make experimenting

--- a/lib/bizside/redmine/client.rb
+++ b/lib/bizside/redmine/client.rb
@@ -40,11 +40,11 @@ class Bizside::Redmine::Client
   def projects(params = {})
     params = params.symbolize_keys
 
-    api_params = {
-      include: 'trackers,issue_categories',
-      page: params[:page] || 1,
-      per: params[:per] || 100
-    }
+    include_value = 'trackers,issue_categories'
+    per = (params[:per] || 100).to_i
+    page = (params[:page] || 1).to_i
+    offset = (page - 1) * per
+    api_params = { include: include_value, limit: per, offset: offset }
 
     response = connection.get("#{prefix}/projects.json", api_params)
     decode(:projects, response)

--- a/lib/bizside/redmine/client/version.rb
+++ b/lib/bizside/redmine/client/version.rb
@@ -1,7 +1,7 @@
 module Bizside
   module Redmine
     class Client
-      VERSION = '0.2.1'
+      VERSION = '0.2.2'
     end
   end
 end

--- a/test/bizside/redmine/client_test.rb
+++ b/test/bizside/redmine/client_test.rb
@@ -23,13 +23,21 @@ class Bizside::Redmine::ClientTest < Minitest::Test
     stub_request(:get, "#{request_host}/projects.json").
       with(query: {
         include: 'trackers,issue_categories',
-        page: 1,
-        per: 100
+        limit: '100',
+        offset: '0'
       }).
       to_return(status: 200, body: response_body)
 
-    result = Bizside::Redmine::ResultSet.new(:projects, 200, response_body)
-    assert_equal @client.projects, result
+    result = @client.projects(page: 1, per: 100)
+    expected = Bizside::Redmine::ResultSet.new(:projects, 200, response_body)
+    assert_equal expected, result
+
+    assert_requested :get, "#{request_host}/projects.json",
+      query: hash_including(
+        limit: '100',
+        offset: '0'
+      ),
+      times: 1
   end
 
   def test_trackers

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,5 @@
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
+require "logger"
 require "bizside/redmine/client"
 
 require "minitest/autorun"


### PR DESCRIPTION
- Updated `Bizside::Redmine::Client#projects` to send `limit`/`offset` parameters to Redmine REST API instead of `page`/`per`, allowing more than 25 projects to be retrieved.
- Added `require 'logger'` before loading ActiveSupport to prevent `NameError` on console startup.